### PR TITLE
Custom hardware component integration

### DIFF
--- a/include/RadioMeshVersion.h
+++ b/include/RadioMeshVersion.h
@@ -2,7 +2,7 @@
 
 #define VERSION_MAJOR 0
 #define VERSION_MINOR 0
-#define VERSION_PATCH 7
+#define VERSION_PATCH 8
 #define VERSION_EXTRA 0
 
 #define RM_VERSION ((((VERSION_MAJOR) << 26) | \

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
     "name": "RadioMesh",
     "keywords": "mesh-network, long-range, low-power, radio, protocol, toolkit, wireless, networking, iot, esp32, arduino",
-    "description": "A library for building low-power, long-range IoT mesh networks using embedded radio devices.",
+    "description": "A library for building wide area mesh networks of embedded devices using long range radios.",
 
     "authors":
     {
@@ -10,7 +10,7 @@
         "url": "https://github.com/amirna2/RadioMesh",
         "maintainer": true
     },
-    "version": "0.0.7",
+    "version": "0.0.8",
     "repository":
     {
         "type": "git",

--- a/src/common/inc/Errors.h
+++ b/src/common/inc/Errors.h
@@ -131,12 +131,12 @@
 #define RM_E_DISPLAY_SETUP                        (-201)
 
 /**
- * @brief The display failed to display.
+ * @brief The display operation failed to complete.
 */
 #define RM_E_DISPLAY_FAILURE                      (-202)
 
 /**
- * @brief The display is not setup.
+ * @brief The display is not setup. Call setup() first.
  */
 #define RM_E_DISPLAY_NOT_SETUP                    (-203)
 
@@ -145,18 +145,30 @@
  */
 #define RM_E_DISPLAY_INVALID_FONT                 (-204)
 
-
-/**
- * @brief The display parameters are invalid.
-
-*/
-#define RM_E_INVALID_DISPLAY_PARAMS               (-205)
-
-
 /**
  * @brief The display failed to draw string.
  */
-#define RM_E_DISPLAY_DRAW_STRING                  (-206)
+#define RM_E_DISPLAY_DRAW_STRING                  (-205)
+
+/**
+ * @brief The display failed to draw number.
+ */
+#define RM_E_DISPLAY_DRAW_NUMBER                  (-206)
+
+/**
+ * @brief The display coordinates are invalid/out of bounds.
+ */
+#define RM_E_DISPLAY_INVALID_COORDS               (-207)
+
+/**
+ * @brief The display rotation is invalid.
+ */
+#define RM_E_DISPLAY_INVALID_ROTATION             (-208)
+
+/**
+ * @brief The display brightness is invalid.
+ */
+#define RM_E_DISPLAY_INVALID_BRIGHTNESS           (-209)
 
 /**
  * @brief SSID in not available.

--- a/src/framework/builder/inc/DeviceBuilder.h
+++ b/src/framework/builder/inc/DeviceBuilder.h
@@ -57,14 +57,6 @@ public:
    DeviceBuilder &withTxPacketCallback(PacketSentCallback callback);
 
    /**
-    * @brief Add AesCrypto to the device with the given key and IV
-    * @param key The key for the AesCrypto
-    * @param iv The IV for the AesCrypto
-    * @return A reference to the updated builder
-   */
-   DeviceBuilder &withAesCrypto(const std::vector<byte>& key, const std::vector<byte>& iv);
-
-   /**
     * @brief Add an OLED display to the device with the given parameters
     * @param params The parameters for the OLED display
     * @return A reference to the updated builder
@@ -103,6 +95,13 @@ public:
    DeviceBuilder& withSecureMessaging(const SecurityParams &params);
 
    /**
+    * @brief Add a custom display to the device
+    * @param display The custom display to add
+    * @return A reference to the updated builder
+   */
+   DeviceBuilder& withCustomDisplay(IDisplay *display);
+
+   /**
     * @brief Build the device
     * @param name The name of the device
     * @param id The ID of the device
@@ -128,13 +127,16 @@ private:
    // Device parameters
    LoraRadioParams radioParams;
    SecurityParams securityParams;
-   bool relayEnabled = false;
-   PacketReceivedCallback rxCallback = nullptr;
-   PacketSentCallback txCallback = nullptr;
    OledDisplayParams oledDisplayParams;
    WifiParams wifiParams = WifiParams();
    WifiAccessPointParams wifiAPParams = WifiAccessPointParams();
    ByteStorageParams storageParams;
+
+   bool relayEnabled = false;
+   PacketReceivedCallback rxCallback = nullptr;
+   PacketSentCallback txCallback = nullptr;
+   IDisplay* customDisplay = nullptr;
+   bool useCustomDisplay = false;
 
    void destroyDevice(IDevice *device) {
       if (device != nullptr) {

--- a/src/framework/device/inc/Device.h
+++ b/src/framework/device/inc/Device.h
@@ -37,7 +37,7 @@ public:
       wifiAccessPoint = nullptr;
 #endif
 #ifndef RM_NO_DISPLAY
-      display = nullptr;
+      oledDisplay = nullptr;
 #endif
       }
 
@@ -117,6 +117,14 @@ public:
    int initializeOledDisplay(OledDisplayParams displayParams);
 
    /**
+    * @brief Set the custom display
+    *
+    * @param display IDisplay object to set
+    * @return RM_E_NONE if the display was successfully set, an error code otherwise.
+    */
+   int setCustomDisplay(IDisplay *display);
+
+   /**
     * @brief Initialize the crypto component
     *
     * @return int RM_E_NONE if the crypto component was successfully initialized, an error code otherwise.
@@ -167,7 +175,8 @@ private:
    EEPROMStorage* eepromStorage = nullptr;
 
 #ifndef RM_NO_DISPLAY
-   OledDisplay* display = nullptr;
+   OledDisplay* oledDisplay = nullptr;
+   IDisplay* customDisplay = nullptr;
 #endif
 
 #ifndef RM_NO_WIFI

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -67,28 +67,42 @@ IDisplay *RadioMeshDevice::getDisplay()
    return nullptr;
 }
 #else
+
+int RadioMeshDevice::setCustomDisplay(IDisplay *display)
+{
+   if (display == nullptr) {
+      logerr_ln("Custom display cannot be null");
+      return RM_E_INVALID_PARAM;
+   }
+   this->customDisplay = display; // Use the provided custom display
+   return RM_E_NONE;
+}
+
 int RadioMeshDevice::initializeOledDisplay(OledDisplayParams displayParams)
 {
    int rc = RM_E_NONE;
 
-   display = OledDisplay::getInstance();
+   oledDisplay = OledDisplay::getInstance();
 
-   if (display == nullptr) {
+   if (oledDisplay == nullptr) {
       logerr_ln("Failed to create display");
       return RM_E_UNKNOWN;
    }
 
-   rc = display->setParams(displayParams);
+   rc = oledDisplay->setParams(displayParams);
    if (rc != RM_E_NONE) {
       logerr_ln("Failed to set display params");
-      display = nullptr;
+      oledDisplay = nullptr;
    }
    return rc;
 }
 
 IDisplay *RadioMeshDevice::getDisplay()
 {
-   return display;
+   if (customDisplay != nullptr) {
+      return customDisplay;
+   }
+   return oledDisplay;
 }
 #endif // RM_NO_DISPLAY
 

--- a/src/framework/interfaces/IDisplay.h
+++ b/src/framework/interfaces/IDisplay.h
@@ -7,27 +7,31 @@
 
 /**
  * @class IDisplay
- * @brief This class is an interface for a display.
+ * @brief Interface for display implementations in the RadioMesh framework
  *
- * It provides the structure for setting up the display component of a device.
- * Use this interface to create specialized display components such as OLED, E-Ink, etc.
+ * This interface defines the contract for display implementations.
+ * Custom display implementations must use the standard RM_E_* error codes
+ * to maintain consistent error handling throughout the system.
  */
 class IDisplay
 {
 public:
    virtual ~IDisplay() {}
 
-   /**
-    * @brief Setup the display with the currently stored parameters.
-    *
-    * @returns RM_E_NONE if the display was successfully setup, an error code otherwise.
-    */
+    /**
+     * @brief Initialize the display hardware
+     *
+     * Must be called after device configuration but before any display operations.
+     * Performs actual hardware initialization.
+     *
+     * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
+     */
    virtual int setup() = 0;
 
    /**
     * @brief Set the display into standby mode.
     * @param save If true, the display will be put into power save mode. If false, the display will be woken up.
-    * @returns RM_E_NONE if the display was successfully put into standby mode, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
     */
    virtual int powerSave(bool save) = 0;
 
@@ -37,7 +41,7 @@ public:
     * @param y The y coordinate of the string.
     * @param clearScreen If true, the screen will be cleared before drawing the string.
     * @param text The text to draw.
-    * @returns RM_E_NONE if the string was successfully drawn, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int drawString(uint8_t x, uint8_t y, const std::string text) = 0;
 
@@ -47,7 +51,7 @@ public:
     * @param y The y coordinate of the string.
     * @param clearScreen If true, the screen will be cleared before drawing the string.
     * @param text The text to draw.
-    * @returns RM_E_NONE if the string was successfully drawn, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int drawString(uint8_t x, uint8_t y, const char* text) = 0;
 
@@ -56,32 +60,32 @@ public:
     * @param x The x coordinate of the number.
     * @param y The y coordinate of the number.
     * @param number The number to draw.
-    * @returns RM_E_NONE if the number was successfully drawn, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int drawNumber(uint8_t x, uint8_t y, int number) = 0;
    /**
     * @brief Set the cursor position of the display.
     * @param x The x coordinate of the cursor.
     * @param y The y coordinate of the cursor.
-    * @returns RM_E_NONE if the cursor was successfully set, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int setCursor(uint8_t x, uint8_t y) = 0;
 
    /**
     * @brief Print a string to the display at the current cursor position.
     * @param text The text to print.
-    * @returns RM_E_NONE if the text was successfully printed, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int print(const std::string text) = 0;
 
    /**
     * @brief Clear the display buffer.
-    * @returns RM_E_NONE if the display buffer was successfully cleared, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int clear() = 0;
    /**
     * @brief Send the display buffer to the display.
-    * @returns RM_E_NONE if the display buffer was successfully sent, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int flush() = 0;
 
@@ -99,14 +103,27 @@ public:
 
    /**
     * @brief Show the splash screen on the display.
-    * @returns RM_E_NONE if the splash screen was successfully shown, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int showSplashScreen() = 0;
 
    /**
     * @brief Set the font of the display.
     * @param fontId The ID of the font to set (e.g RM_FONT_MEDIUM)
-    * @returns RM_E_NONE if the font was successfully set, an error code otherwise.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
    */
    virtual int setFont(uint8_t fontId) = 0;
+
+   /**
+    * @brief Set the parameters of the display.
+    * @param params The parameters to set.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
+   */
+   virtual int setBrightness(uint8_t level) = 0;
+   /**
+    * @brief Set the rotation of the display.
+    * @param rotation The rotation to set.
+    * @return RM_E_NONE Success. A RadioMesh error (RM_E_*) code on failure.
+   */
+   virtual int setRotation(uint8_t rotation) = 0;
 };

--- a/src/hardware/inc/display/oled/OledDisplay.h
+++ b/src/hardware/inc/display/oled/OledDisplay.h
@@ -45,8 +45,12 @@ public:
    uint8_t getWidth() override { return 0; }
    uint8_t getHeight() override { return 0; }
    int setFont(uint8_t fontId) override { return RM_E_NOT_SUPPORTED; }
-   int setParams(const OledDisplayParams& params) { return RM_E_NOT_SUPPORTED; }
    int drawNumber(uint8_t x, uint8_t y, int number) override { return RM_E_NOT_SUPPORTED; }
+
+   int setParams(const OledDisplayParams& params) { return RM_E_NOT_SUPPORTED; }
+   int setBrightness(uint8_t brightness) override { return RM_E_NOT_SUPPORTED; }
+   int setRotation(uint8_t rotation) override { return RM_E_NOT_SUPPORTED; }
+
 #else
    int setup() override;
    int powerSave(bool save) override;
@@ -61,6 +65,10 @@ public:
    uint8_t getHeight() override;
    int setFont(uint8_t fontId) override;
    int drawNumber(uint8_t x, uint8_t y, int number) override;
+
+   int setBrightness(uint8_t brightness) override { return RM_E_NOT_SUPPORTED; }
+   int setRotation(uint8_t rotation) override { return RM_E_NOT_SUPPORTED; }
+
    int setParams(const OledDisplayParams& params);
 #endif
 

--- a/src/hardware/src/display/oled/OledDisplay.cpp
+++ b/src/hardware/src/display/oled/OledDisplay.cpp
@@ -32,7 +32,7 @@ int OledDisplay::setup() {
    }
 
    u8g2->clearDisplay();
-   drawString(5, 40, "W.A.R.P. SDK");
+   drawString(5, 40, "RadioMesh");
    drawString(5, 54, "v" + RadioMeshUtils::getVersion());
 
    width = u8g2->getCols();
@@ -142,8 +142,9 @@ uint8_t OledDisplay::getHeight() {
 
 int OledDisplay::setFont(uint8_t fontId) {
    if (u8g2 == nullptr) {
-      return RM_E_UNKNOWN;
+      return RM_E_DISPLAY_NOT_SETUP;
    }
+
    if (fontId == RM_FONT_TINY) {
       u8g2->setFont(u8g2_font_5x7_tf);
    } else if (fontId == RM_FONT_SMALL) {
@@ -155,7 +156,7 @@ int OledDisplay::setFont(uint8_t fontId) {
    } else if (fontId == RM_FONT_BATTERY) {
       u8g2->setFont(u8g2_font_battery19_tn);
    } else {
-      return RM_E_INVALID_PARAM;
+      return RM_E_DISPLAY_INVALID_FONT;
    }
    return RM_E_NONE;
 }

--- a/test/test_CustomDisplay/CustomDisplay.cpp
+++ b/test/test_CustomDisplay/CustomDisplay.cpp
@@ -1,0 +1,193 @@
+#include "CustomDisplay.h"
+
+// This module is a mock of the IDisplay interface.
+// It is used to test custom display integration with the DeviceBuilder.
+
+CustomDisplay::CustomDisplay()
+{
+
+}
+
+int CustomDisplay::setup()
+{
+   this->isSetup = true;
+   return RM_E_NONE;
+}
+
+int CustomDisplay::powerSave(bool save)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+   this->inPowerSave = save;
+   return RM_E_NONE;
+}
+
+int CustomDisplay::drawString(uint8_t x, uint8_t y, const std::string text)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (x >= width || y >= height)
+   {
+      return RM_E_DISPLAY_INVALID_COORDS;
+   }
+
+   return RM_E_NONE;
+}
+
+int CustomDisplay::drawString(uint8_t x, uint8_t y, const char* text)
+{
+
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (x >= width || y >= height)
+   {
+      return RM_E_DISPLAY_INVALID_COORDS;
+   }
+
+   return RM_E_NONE;
+}
+
+int CustomDisplay::setCursor(uint8_t x, uint8_t y)
+{
+
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (x >= width || y >= height)
+   {
+      return RM_E_DISPLAY_INVALID_COORDS;
+   }
+
+   this->cursorX = x;
+   this->cursorY = y;
+   return RM_E_NONE;
+}
+
+int CustomDisplay::print(const std::string text)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   return RM_E_NONE;
+}
+
+int CustomDisplay::clear()
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   return RM_E_NONE;
+}
+
+int CustomDisplay::flush()
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   return RM_E_NONE;
+}
+
+int CustomDisplay::showSplashScreen()
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   return RM_E_NONE;
+}
+
+uint8_t CustomDisplay::getWidth()
+{
+   if (!this->isSetup)
+   {
+      return 0;
+   }
+
+   return width;
+}
+
+uint8_t CustomDisplay::getHeight()
+{
+   if (!this->isSetup)
+   {
+      return 0;
+   }
+   return height;
+}
+
+int CustomDisplay::setFont(uint8_t fontId)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (fontId != CUSTOM_DISPLAY_FONT_SMALL && fontId != CUSTOM_DISPLAY_FONT_MEDIUM && fontId != CUSTOM_DISPLAY_FONT_LARGE)
+   {
+      return RM_E_DISPLAY_INVALID_FONT;
+   }
+   this->fontId = fontId;
+   return RM_E_NONE;
+}
+
+int CustomDisplay::drawNumber(uint8_t x, uint8_t y, int number)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (x >= width || y >= height)
+   {
+      return RM_E_DISPLAY_INVALID_COORDS;
+   }
+   return RM_E_NONE;
+}
+
+int CustomDisplay::setBrightness(uint8_t brightness)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (brightness > 100)
+   {
+      return RM_E_DISPLAY_INVALID_BRIGHTNESS;
+   }
+   return RM_E_NONE;
+}
+
+int CustomDisplay::setRotation(uint8_t rotation)
+{
+   if (!this->isSetup)
+   {
+      return RM_E_DISPLAY_NOT_SETUP;
+   }
+
+   if (rotation > 3)
+   {
+      return RM_E_DISPLAY_INVALID_ROTATION;
+   }
+   return RM_E_NONE;
+}
+
+
+

--- a/test/test_CustomDisplay/CustomDisplay.h
+++ b/test/test_CustomDisplay/CustomDisplay.h
@@ -1,0 +1,49 @@
+// This module is a mock of the IDisplay interface.
+// It is used to test custom display integration with the DeviceBuilder.
+
+#pragma once
+
+#include <RadioMesh.h>
+
+#define CUSTOM_DISPLAY_WIDTH 128
+#define CUSTOM_DISPLAY_HEIGHT 64
+
+#define CUSTOM_DISPLAY_FONT_SMALL 0
+#define CUSTOM_DISPLAY_FONT_MEDIUM 1
+#define CUSTOM_DISPLAY_FONT_LARGE 2
+
+class CustomDisplay : public IDisplay
+{
+public:
+   CustomDisplay() {}
+   virtual ~CustomDisplay() {}
+
+   int setup() override;
+   int powerSave(bool save) override;
+   int drawString(uint8_t x, uint8_t y, const std::string text) override;
+   int drawString(uint8_t x, uint8_t y, const char* text) override;
+   int setCursor(uint8_t x, uint8_t y) override;
+   int print(const std::string text) override;
+   int clear() override;
+   int flush() override;
+   int showSplashScreen() override;
+   uint8_t getWidth() override;
+   uint8_t getHeight() override;
+   int setFont(uint8_t fontId) override;
+   int drawNumber(uint8_t x, uint8_t y, int number) override;
+
+   int setBrightness(uint8_t brightness) override;
+   int setRotation(uint8_t rotation) override;
+
+private:
+   uint8_t width = CUSTOM_DISPLAY_WIDTH;
+   uint8_t height = CUSTOM_DISPLAY_HEIGHT;
+   uint8_t fontId = CUSTOM_DISPLAY_FONT_MEDIUM;
+   uint8_t brightness = 50;
+   uint8_t rotation = 0;
+   bool inPowerSave = false;
+   bool isSetup = false;
+
+   uint8_t cursorX = 0;
+   uint8_t cursorY = 0;
+};

--- a/test/test_CustomDisplay/test_CustomDisplay.cpp
+++ b/test/test_CustomDisplay/test_CustomDisplay.cpp
@@ -1,0 +1,41 @@
+#include <unity.h>
+#include <RadioMesh.h>
+#include "CustomDisplay.h"
+
+const std::array<byte, DEV_ID_LENGTH> device_id = {0x11, 0x11, 0x11, 0x11};
+const std::string DEVICE_NAME = "TestDevice";
+
+IDevice *device = nullptr;
+
+void reset_device()
+{
+   if (device != nullptr) {
+      delete device;
+   }
+   device = nullptr;
+}
+
+
+void test_DeviceBuilder_buildDevice_withCustomDisplay(void)
+{
+   DeviceBuilder builder;
+   reset_device();
+   device = builder.start()
+                   .withCustomDisplay(nullptr)
+                   .withRelayEnabled(true)
+                   .build("test", device_id, MeshDeviceType::STANDARD);
+
+   TEST_ASSERT_NOT_NULL(device->getDisplay());
+}
+
+
+void setup()
+{
+   UNITY_BEGIN();
+   RUN_TEST(test_DeviceBuilder_buildDevice_withCustomDisplay);
+   UNITY_END();
+}
+
+void loop()
+{
+}


### PR DESCRIPTION
### Description
Adds a support in the DeviceBuilder to create a device with custom components.
This first iteration adds custom display
```
   /**
    * @brief Add a custom display to the device
    * @param display The custom display to add
    * @return A reference to the updated builder
   */
   DeviceBuilder& withCustomDisplay(IDisplay *display);
```

### Related Issue(s)


### Type of Change
<!-- Put an 'x' in all boxes that apply -->
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Infrastructure/Build update
- [ ] Other <!-- Please describe: -->


### Testing
- Added a `test_CustomDisplay` unit test to test a Mock Display implementation

### Screenshots
<!-- If applicable, add screenshots to help explain your changes -->


### Additional Notes
<!-- Any other context or information you'd like to provide -->
