### PR TITLE
fix MIC verification failure on INCLUDE_RESPONSE

### DIFF
--- a/src/core/protocol/src/routing/PacketRouter.cpp
+++ b/src/core/protocol/src/routing/PacketRouter.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -26,8 +27,11 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
 
     packetCopy.reserved.fill(0);
 
-    // For relayed packets, ensure any existing MIC is stripped before recomputation
-    if (packetCopy.hasMIC()) {
+    // Only strip an existing MIC when relaying. A freshly originated packet has no MIC yet,
+    // and stripping unconditionally would lop 4 bytes off the real payload.
+    bool isOriginator = std::equal(packetCopy.sourceDevId.begin(),
+                                   packetCopy.sourceDevId.end(), ourDeviceId);
+    if (!isOriginator && packetCopy.hasMIC()) {
         logdbg_ln("Stripping existing MIC from relayed packet for topic 0x%02X", packetCopy.topic);
         packetCopy.packetData = packetCopy.getDataWithoutMIC();
     }
@@ -36,13 +40,16 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
         encryptPacketData(packetCopy, deviceType, inclusionState);
     }
 
-    // Compute and append MIC after encryption
+    // CRC must be computed before MIC: the MIC authenticates the header bytes that are actually
+    // transmitted, and the header includes packetCrc. CRC covers payload-without-MIC; the MIC
+    // provides its own cryptographic integrity over header + encrypted payload.
+    calculatePacketCrc(packetCopy, crc32, key);
+
     int micResult = computeAndAppendMIC(packetCopy, deviceType, inclusionState);
     if (micResult != RM_E_NONE) {
         return micResult;
     }
 
-    calculatePacketCrc(packetCopy, crc32, key);
     int rc = sendPacket(packetCopy);
     if (rc != RM_E_NONE) {
         return rc;

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -299,7 +299,13 @@ bool RadioMeshDevice::isReceivedDataCrcValid(RadioMeshPacket& receivedPacket)
 {
     RadioMeshUtils::CRC32 crc32;
     crc32.update(receivedPacket.fcounter);
-    crc32.update(receivedPacket.packetData.data(), receivedPacket.packetData.size());
+
+    // CRC covers payload without MIC, mirroring the sender (PacketRouter computes CRC before
+    // appending the MIC). For topics without a MIC, getDataWithoutMIC returns the full payload.
+    std::vector<byte> dataForCrc = receivedPacket.getDataWithoutMIC();
+    if (!dataForCrc.empty()) {
+        crc32.update(dataForCrc.data(), dataForCrc.size());
+    }
     uint32_t computed_data_crc = crc32.finalize();
     crc32.reset();
 


### PR DESCRIPTION
## Summary
- MIC authenticates the 35-byte header (which contains `packetCrc`), but the sender computed the MIC *before* calculating the CRC. The MIC covered a stale CRC field while the wire packet carried the real CRC, so the receiver always saw a header mismatch and rejected every MIC-bearing packet (first observed on `INCLUDE_RESPONSE`).
- Gate the relay MIC-strip in `PacketRouter::routePacket` on `isOriginator`. The unconditional strip removed the last 4 bytes of any payload whose topic required a MIC. For a hub originating `INCLUDE_RESPONSE`, this turned `[networkKey 32B][nonce 4B]` into `[networkKey 32B]` *before* encryption — leaving the device 4 bytes short after MIC verification would have passed.
- Receive-side CRC mirrored: `Device::isReceivedDataCrcValid` now CRCs over `getDataWithoutMIC()` so both sides agree. For topics without a MIC (`INCLUDE_OPEN`, `INCLUDE_REQUEST`), `getDataWithoutMIC` returns the full payload, so behavior is unchanged.

## Test plan
- [x] Builds clean for `heltec_wifi_lora_32_V3`
- [x] Builds clean for `cubecell_board_v2`
- [x] Flash hub + standard device, run DeviceInclusion examples, confirm `INCLUDE_OPEN → INCLUDE_REQUEST → INCLUDE_RESPONSE → INCLUDE_CONFIRM → INCLUDE_SUCCESS` completes
- [x] Confirm post-inclusion AES-encrypted application traffic also passes MIC verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)