### PR TITLE
Decrypt message before passing to callback

### DIFF
--- a/src/core/protocol/src/routing/PacketRouter.cpp
+++ b/src/core/protocol/src/routing/PacketRouter.cpp
@@ -27,14 +27,6 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
 
     packetCopy.reserved.fill(0);
 
-    // Only strip an existing MIC when relaying. A freshly originated packet has no MIC yet,
-    // and stripping unconditionally would lop 4 bytes off the real payload.
-    bool isOriginator = std::equal(packetCopy.sourceDevId.begin(),
-                                   packetCopy.sourceDevId.end(), ourDeviceId);
-    if (!isOriginator && packetCopy.hasMIC()) {
-        logdbg_ln("Stripping existing MIC from relayed packet for topic 0x%02X", packetCopy.topic);
-        packetCopy.packetData = packetCopy.getDataWithoutMIC();
-    }
 
     if (packetCopy.topic != MessageTopic::INCLUDE_OPEN) {
         encryptPacketData(packetCopy, deviceType, inclusionState);

--- a/src/framework/device/inc/Device.h
+++ b/src/framework/device/inc/Device.h
@@ -245,4 +245,5 @@ private:
     bool verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket);
     bool canSendMessage(uint8_t topic) const;
     bool isInclusionMessage(uint8_t topic) const;
+    bool isApplicationMessage(uint8_t topic) const;
 };

--- a/src/framework/device/inc/Device.h
+++ b/src/framework/device/inc/Device.h
@@ -242,7 +242,7 @@ private:
     RadioMeshPacket txPacket = RadioMeshPacket();
 
     bool isReceivedDataCrcValid(RadioMeshPacket& receivedPacket);
-    bool verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket);
+    bool verifyAndStripReceivedPacketMIC(RadioMeshPacket& receivedPacket);
     bool canSendMessage(uint8_t topic) const;
     bool isInclusionMessage(uint8_t topic) const;
     bool isApplicationMessage(uint8_t topic) const;

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -350,7 +350,7 @@ int RadioMeshDevice::handleReceivedData()
     }
 
     // Verify MIC before any further processing
-    if (!verifyReceivedPacketMIC(receivedPacket)) {
+    if (!verifyAndStripReceivedPacketMIC(receivedPacket)) {
         logerr_ln("ERROR handleReceivedPacket. MIC verification failed");
         return RM_E_AUTH_FAILED;
     }
@@ -618,7 +618,7 @@ int RadioMeshDevice::updateSecurityParams(const SecurityParams& params)
     return RM_E_NONE;
 }
 
-bool RadioMeshDevice::verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket)
+bool RadioMeshDevice::verifyAndStripReceivedPacketMIC(RadioMeshPacket& receivedPacket)
 {
     // Public key exchange messages don't have MIC
     if (receivedPacket.topic == MessageTopic::INCLUDE_OPEN ||

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -26,6 +26,10 @@ bool RadioMeshDevice::isInclusionMessage(uint8_t topic) const
 {
     return (topic >= INCLUDE_REQUEST && topic <= INCLUDE_SUCCESS);
 }
+bool RadioMeshDevice::isApplicationMessage(uint8_t topic) const
+{
+    return topic > MAX_RESERVED;
+}
 
 std::array<byte, RM_ID_LENGTH> RadioMeshDevice::getDeviceId()
 {
@@ -384,6 +388,13 @@ int RadioMeshDevice::handleReceivedData()
 
         // Don't forward inclusion messages
         return result;
+    }
+
+    // Decrypting if it is an application message
+    if (isApplicationMessage(receivedPacket.topic)) {
+        receivedPacket.packetData =
+            encryptionService.decrypt(receivedPacket.packetData, receivedPacket.topic,
+                                     deviceType, inclusionController->getState());
     }
 
     // Packet has reached its destination or the device is a HUB, let the application handle it


### PR DESCRIPTION
### Description
<!-- What changes does this PR introduce? -->
During my tests I couldn't reliably receive the sent data. I received binary data that didn't correspond to the sent data.

I read how `PacketRouter::routePacket(...)` and `RadioMeshDevice::handleReceivedData()` work and I found that the former encrypts the data, while the latter doesn't decrypt it.
So, I added the decryption part.

It decrypts the data only if it is an application message (`packet.topic > MessageTopic::MAX_RESERVED`), because I didn't want to interfere with library-handled packets (inclusion ecc...). If you think it's a unuseful check, you (or I) can commit to this branch to remove the check.

Thank you for this library!

Edit: in the second commit I fixed MIC stripping, [in the following comment](https://github.com/amirna2/RadioMesh/pull/34#issuecomment-4460140859) I explained it better.

### Related Issue(s)
<!-- Link to the issue(s) this PR addresses -->
None.

### Type of Change
<!-- Put an 'x' in all boxes that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/Build update
- [ ] Other <!-- Please describe: -->


### Testing
<!-- Describe the tests you've done -->
Tests with 2 CubeCell devices, one HUB and the other one STANDARD with relay disabled.