### PR TITLE
Integrate #34: decrypt message before callback + MIC strip cleanup

### DIFF
--- a/src/core/protocol/src/routing/PacketRouter.cpp
+++ b/src/core/protocol/src/routing/PacketRouter.cpp
@@ -27,14 +27,6 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
 
     packetCopy.reserved.fill(0);
 
-    // Only strip an existing MIC when relaying. A freshly originated packet has no MIC yet,
-    // and stripping unconditionally would lop 4 bytes off the real payload.
-    bool isOriginator = std::equal(packetCopy.sourceDevId.begin(),
-                                   packetCopy.sourceDevId.end(), ourDeviceId);
-    if (!isOriginator && packetCopy.hasMIC()) {
-        logdbg_ln("Stripping existing MIC from relayed packet for topic 0x%02X", packetCopy.topic);
-        packetCopy.packetData = packetCopy.getDataWithoutMIC();
-    }
 
     if (packetCopy.topic != MessageTopic::INCLUDE_OPEN) {
         encryptPacketData(packetCopy, deviceType, inclusionState);

--- a/src/core/protocol/src/routing/PacketRouter.cpp
+++ b/src/core/protocol/src/routing/PacketRouter.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -26,8 +27,11 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
 
     packetCopy.reserved.fill(0);
 
-    // For relayed packets, ensure any existing MIC is stripped before recomputation
-    if (packetCopy.hasMIC()) {
+    // Only strip an existing MIC when relaying. A freshly originated packet has no MIC yet,
+    // and stripping unconditionally would lop 4 bytes off the real payload.
+    bool isOriginator = std::equal(packetCopy.sourceDevId.begin(),
+                                   packetCopy.sourceDevId.end(), ourDeviceId);
+    if (!isOriginator && packetCopy.hasMIC()) {
         logdbg_ln("Stripping existing MIC from relayed packet for topic 0x%02X", packetCopy.topic);
         packetCopy.packetData = packetCopy.getDataWithoutMIC();
     }
@@ -36,13 +40,16 @@ int PacketRouter::routePacket(RadioMeshPacket packet, const byte* ourDeviceId,
         encryptPacketData(packetCopy, deviceType, inclusionState);
     }
 
-    // Compute and append MIC after encryption
+    // CRC must be computed before MIC: the MIC authenticates the header bytes that are actually
+    // transmitted, and the header includes packetCrc. CRC covers payload-without-MIC; the MIC
+    // provides its own cryptographic integrity over header + encrypted payload.
+    calculatePacketCrc(packetCopy, crc32, key);
+
     int micResult = computeAndAppendMIC(packetCopy, deviceType, inclusionState);
     if (micResult != RM_E_NONE) {
         return micResult;
     }
 
-    calculatePacketCrc(packetCopy, crc32, key);
     int rc = sendPacket(packetCopy);
     if (rc != RM_E_NONE) {
         return rc;

--- a/src/framework/device/inc/Device.h
+++ b/src/framework/device/inc/Device.h
@@ -245,4 +245,5 @@ private:
     bool verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket);
     bool canSendMessage(uint8_t topic) const;
     bool isInclusionMessage(uint8_t topic) const;
+    bool isApplicationMessage(uint8_t topic) const;
 };

--- a/src/framework/device/inc/Device.h
+++ b/src/framework/device/inc/Device.h
@@ -242,7 +242,7 @@ private:
     RadioMeshPacket txPacket = RadioMeshPacket();
 
     bool isReceivedDataCrcValid(RadioMeshPacket& receivedPacket);
-    bool verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket);
+    bool verifyAndStripReceivedPacketMIC(RadioMeshPacket& receivedPacket);
     bool canSendMessage(uint8_t topic) const;
     bool isInclusionMessage(uint8_t topic) const;
     bool isApplicationMessage(uint8_t topic) const;

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -350,7 +350,7 @@ int RadioMeshDevice::handleReceivedData()
     }
 
     // Verify MIC before any further processing
-    if (!verifyReceivedPacketMIC(receivedPacket)) {
+    if (!verifyAndStripReceivedPacketMIC(receivedPacket)) {
         logerr_ln("ERROR handleReceivedPacket. MIC verification failed");
         return RM_E_AUTH_FAILED;
     }
@@ -618,7 +618,7 @@ int RadioMeshDevice::updateSecurityParams(const SecurityParams& params)
     return RM_E_NONE;
 }
 
-bool RadioMeshDevice::verifyReceivedPacketMIC(RadioMeshPacket& receivedPacket)
+bool RadioMeshDevice::verifyAndStripReceivedPacketMIC(RadioMeshPacket& receivedPacket)
 {
     // Public key exchange messages don't have MIC
     if (receivedPacket.topic == MessageTopic::INCLUDE_OPEN ||

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -26,6 +26,10 @@ bool RadioMeshDevice::isInclusionMessage(uint8_t topic) const
 {
     return (topic >= INCLUDE_REQUEST && topic <= INCLUDE_SUCCESS);
 }
+bool RadioMeshDevice::isApplicationMessage(uint8_t topic) const
+{
+    return topic > MAX_RESERVED;
+}
 
 std::array<byte, RM_ID_LENGTH> RadioMeshDevice::getDeviceId()
 {
@@ -384,6 +388,13 @@ int RadioMeshDevice::handleReceivedData()
 
         // Don't forward inclusion messages
         return result;
+    }
+
+    // Decrypting if it is an application message
+    if (isApplicationMessage(receivedPacket.topic)) {
+        receivedPacket.packetData =
+            encryptionService.decrypt(receivedPacket.packetData, receivedPacket.topic,
+                                     deviceType, inclusionController->getState());
     }
 
     // Packet has reached its destination or the device is a HUB, let the application handle it

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -299,7 +299,13 @@ bool RadioMeshDevice::isReceivedDataCrcValid(RadioMeshPacket& receivedPacket)
 {
     RadioMeshUtils::CRC32 crc32;
     crc32.update(receivedPacket.fcounter);
-    crc32.update(receivedPacket.packetData.data(), receivedPacket.packetData.size());
+
+    // CRC covers payload without MIC, mirroring the sender (PacketRouter computes CRC before
+    // appending the MIC). For topics without a MIC, getDataWithoutMIC returns the full payload.
+    std::vector<byte> dataForCrc = receivedPacket.getDataWithoutMIC();
+    if (!dataForCrc.empty()) {
+        crc32.update(dataForCrc.data(), dataForCrc.size());
+    }
     uint32_t computed_data_crc = crc32.finalize();
     crc32.reset();
 


### PR DESCRIPTION
Integrates the changes from #34 by @andrea3x into `main`.

#34 targeted the `fix-mic-crc-ordering` feature branch, which had already been squash-merged into `main`, so it could not be retargeted cleanly. This PR carries Andrea's two original commits (authored by him) onto `main` via merge.

Net change is byte-identical to the reviewed #34 diff (+15/-11 across 3 files):
- `PacketRouter.cpp`: remove now-dead MIC-strip-on-relay block (MIC already stripped on receive)
- `Device.cpp`/`Device.h`: decrypt application messages before the rx callback; rename verify->verifyAndStrip

Credit: @andrea3x (first external contribution). Original PR: #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)