### PR TITLE
Tracking packet right after it's received

### DIFF
--- a/src/core/protocol/inc/routing/PacketRouter.h
+++ b/src/core/protocol/inc/routing/PacketRouter.h
@@ -59,6 +59,13 @@ public:
     bool isPacketFoundInTracker(RadioMeshPacket packet);
 
     /**
+     * @brief Track packet.
+     * If a packet with the same id is already present, the old packet is overridden.
+     * @param packet RadioMeshPacket to add to tracking.
+     */
+    void trackPacket(RadioMeshPacket& packet);
+
+    /**
      * @brief Set the encryption service to use for encrypting and decrypting packets.
      * @param encryptionService EncryptionService component to use
      */

--- a/src/core/protocol/src/routing/PacketRouter.cpp
+++ b/src/core/protocol/src/routing/PacketRouter.cpp
@@ -135,6 +135,12 @@ void PacketRouter::trackPacket(RadioMeshPacket& packetCopy, uint32_t key)
     packetTracker.addEntry(key, packetCopy.packetCrc);
 }
 
+void PacketRouter::trackPacket(RadioMeshPacket& packet)
+{
+    uint32_t key = RadioMeshUtils::toUint32(packet.packetId.data());
+    trackPacket(packet, key);
+}
+
 int PacketRouter::computeAndAppendMIC(RadioMeshPacket& packetCopy, MeshDeviceType deviceType,
                                       DeviceInclusionState inclusionState)
 {

--- a/src/framework/device/src/Device.cpp
+++ b/src/framework/device/src/Device.cpp
@@ -342,6 +342,8 @@ int RadioMeshDevice::handleReceivedData()
     if (router->isPacketFoundInTracker(receivedPacket)) {
         logwarn_ln("Packet already seen. Ignoring...");
         return RM_E_NONE;
+    } else {
+        PacketRouter::getInstance()->trackPacket(receivedPacket);
     }
 
     if (!isReceivedDataCrcValid(receivedPacket)) {


### PR DESCRIPTION
### Description
If the receiver is near both the sender and a repeater (standard device with relay enabled), it would receive **twice** the same packet because **a packet is only tracked during routing and not when receiving**.

This commit fixes it.

Once again, I did my best to adhere to simplicity and your coding style. I hope it's ok :)

Thanks


### Type of Change
<!-- Put an 'x' in all boxes that apply -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/Build update
- [ ] Other <!-- Please describe: -->


### Testing
Tests with 3 CubeCell devices, 2 with relay disabled and one with relay enabled.
