### PR TITLE
Refactor/dearduinofy core slice

### DIFF
--- a/docs/superpowers/plans/2026-07-18-zephyr-port-m0-HANDOFF.md
+++ b/docs/superpowers/plans/2026-07-18-zephyr-port-m0-HANDOFF.md
@@ -1,0 +1,103 @@
+# M0 Execution Handoff — RadioMesh → Zephyr Port
+
+**Purpose:** Resume **inline execution** of Milestone 0 in a fresh (post-compaction) session with
+zero re-derivation. Read this doc, then the plan, then execute. Everything needed is in-repo.
+
+---
+
+## TL;DR — how to resume
+
+1. `cd /Users/nathoo/dev/RadioMesh`, then `git checkout refactor/dearduinofy-core-slice`.
+   Verify: `git status` is clean and `git log --oneline -3` shows the three docs commits listed
+   under **State** below.
+2. Read the plan: `docs/superpowers/plans/2026-07-18-zephyr-port-m0-dearduinofy.md`.
+   (Optional deeper context: spec `.../specs/2026-07-18-zephyr-port-milestone0-design.md`.)
+3. Invoke the **`superpowers:executing-plans`** skill and work Task 1 → 2 → 3 in order. TDD:
+   write test → run to see it fail → apply the fix → run to green → run the Arduino gate → commit.
+   Checkpoint with the user between tasks.
+4. Commit per the **`git-workflow`** skill: conventional-commit prefix, one-line trailer
+   `Assisted-by: Claude Code (<model>)`, **never commit to `main`**, stay on this branch.
+
+---
+
+## State (as of 2026-07-18)
+
+- **Branch:** `refactor/dearduinofy-core-slice` (branched off `main`).
+- **Commits so far — DOCS ONLY, no source code changed yet:**
+  - `004e184` — spec
+  - `5c0a08d` — spec correction (real de-Arduino surface)
+  - `1253cd7` — implementation plan
+- Working tree clean. Nothing pushed. `main` untouched.
+- **Execution mode chosen by user: inline (option 2).**
+
+## What M0 is
+
+Make the protocol core's **packet slice** compile with **zero Arduino dependency**, guarded so
+the Arduino build is byte-identical, and prove it with a new host `native` test.
+
+**Two gates — both must stay green:**
+1. `pio run -e heltec_wifi_lora_32_V3` **and** `pio run -e seeed_xiao_esp32s3` still build.
+2. `pio test -e native` compiles the slice with no Arduino and passes.
+
+## The 6 files (exact changes are in the plan)
+
+| File | Change |
+|---|---|
+| `platformio.ini` | add `[env:native]` (platform=native, no framework, unity, `test_filter=test_Packet`, `lib_ldf_mode=off`, `-std=gnu++17 -I ./include -I ./src`) |
+| `src/common/utils/RadioMeshCrc32.h` | drop `#include <Arduino.h>` → `<cstddef>`+`<cstdint>` (unconditional; uses no `byte`) |
+| `src/common/inc/Options.h` | in the `#else` (`RM_GENERIC_BUILD`) branch add `#include <cstdint>` + `typedef uint8_t byte;` |
+| `src/common/inc/Logger.h` | host output path in `rmPrintf` + guarded `<cstdarg>/<cstdio>/<new>` |
+| `src/common/utils/Utils.h` | guard the Arduino RNG (`random`/`randomSeed`) in `getRandomBytesArray` |
+| `test/test_Packet/test_Packet.cpp` | **create** — host tests (smoke, CRC props, Packet round-trip) |
+
+## Non-obvious gotchas (why the plan looks the way it does)
+
+- **`byte` is an Arduino typedef.** Off-Arduino it's undefined; `Options.h` already has a dead
+  `RM_GENERIC_BUILD` (`#else`) branch — that's where the `byte` typedef goes.
+- **`Logger.h` does not compile off-Arduino as-is.** `rmPrintf` (defined unconditionally) calls
+  `OUTPUT_PORT.write(...)`; `OUTPUT_PORT` is `#define`d **only** under `defined(ARDUINO)`. Add an
+  `#else` path `fwrite(buffer, 1, len, stdout)`. Key the new includes on the **same**
+  `!defined(ARDUINO)` condition (not `RM_ARDUINO_BUILD`) so guard and output can't diverge.
+- **`Utils.h` has Arduino RNG inside a template.** `getRandomBytesArray` calls `random()` /
+  `randomSeed()`. These are *non-dependent* names → **clang (the macOS `native` compiler) rejects
+  them at template definition, even though nothing instantiates it.** Fix: guard the RNG loop and
+  use `std::rand()` on host. Do **not** declare a global `random(long)` — it clashes with POSIX
+  `long random(void)`.
+- **CRC32 is non-standard** (reflects both input bytes and output). Do NOT assert a canonical
+  CRC-32 constant like `0xCBF43926`; the plan uses property tests (determinism, change-detection).
+- **The native test must NOT use the Arduino harness.** Use `int main()` (+ empty
+  `setUp`/`tearDown`), include slice headers **directly** (`Packet.h`, `RadioMeshCrc32.h`) — never
+  the `RadioMesh.h` umbrella (it pulls RadioLib/WiFi) — and define **no** `RM_LOG_*` (log macros
+  stay no-ops, so the stdout path isn't even exercised).
+- **Existing `test_*` suites are Arduino-only** (`#include <RadioMesh.h>`, `setup()/loop()`).
+  `test_filter = test_Packet` keeps them out of the `native` env.
+- The round-trip slice is **header-only** — the `native` env compiles no `src/*.cpp`
+  (`Utils.cpp` is untouched this milestone).
+
+## Constraints / out of scope (do NOT do in M0)
+
+- No Zephyr / `ports/zephyr/` content, no `zephyr/module.yml` (that's M1).
+- No file relocation or directory restructure.
+- No changes to crypto, routing, framework, `DeviceBuilder`, `IRadio`, or `Utils.cpp` internals.
+- No Zephyr `printk`/`LOG_*` logging backend (M1) — M0 adds only the generic stdout path.
+
+## Environment prerequisites
+
+- PlatformIO CLI (`pio`) installed and on PATH.
+- Internet access for the **first** `pio test -e native` (PlatformIO fetches the `native`
+  platform on first use).
+- **No ESP32 hardware needed for M0** — the Arduino gate is a *compile* (`pio run`), and the
+  functional tests run on the host. (On-device Unity suites are out of scope this milestone.)
+
+## Definition of done
+
+All boxes in the plan's "Verification Summary" green: `pio test -e native` passes (4 tests);
+both board builds succeed; all shared-file edits guarded; nothing changed outside the 6 files.
+
+## After M0 (context for later, not now)
+
+M1 = Zephyr bring-up + two-node LoRa exchange. Facts already researched (see spec §1 / memory
+`project_zephyr_port.md`): board target `xiao_esp32s3/esp32s3/procpu`; SX1262 wiring SPI
+SCK7/MISO8/MOSI9, CS41/RST42/BUSY40/DIO1 39, DIO2→RF-switch, DIO3→TCXO 1.8V; driver
+`semtech,sx1262` + `<zephyr/drivers/lora.h>`; pin Zephyr v4.4.0; prior art `liquidraver/zephcore`
+and `tensop-au/zephyr-esp32s3-lorawan-fuota` (ready overlay).

--- a/docs/superpowers/plans/2026-07-18-zephyr-port-m0-dearduinofy.md
+++ b/docs/superpowers/plans/2026-07-18-zephyr-port-m0-dearduinofy.md
@@ -1,0 +1,432 @@
+# Zephyr Port — Milestone 0 (De-Arduino-ify Core Packet Slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the protocol core's packet slice compile with zero Arduino dependency (guarded so the Arduino build is byte-identical), and prove it via a new host `native` test.
+
+**Architecture:** Add a PlatformIO `native` (host, frameworkless) test env that compiles a header-only slice of the core — `RadioMeshPacket` + `CRC32` — with no Arduino. Every shared-file edit is guarded by the existing `RM_ARDUINO_BUILD` / `RM_GENERIC_BUILD` macros so the Arduino preprocessor output does not change. Two gates must stay green: the Arduino firmware still builds, and the slice compiles + round-trips on the host.
+
+**Tech Stack:** PlatformIO, Unity test framework, C++17, host `g++`/clang (PlatformIO `native` platform), target ESP32-S3 (`heltec_wifi_lora_32_V3`, `seeed_xiao_esp32s3`).
+
+## Global Constraints
+
+Every task's requirements implicitly include these (values copied from the spec):
+
+- **C++ standard:** `-std=gnu++17` on every env.
+- **Guard macro:** all shared-file edits gated by `RM_ARDUINO_BUILD` (Arduino) / `RM_GENERIC_BUILD` (host) — both defined at the top of `src/common/inc/Options.h`. Arduino-branch preprocessor output must stay byte-identical.
+- **Native test rules:** the host test uses `int main()` (NOT Arduino `setup()/loop()`); includes slice headers **directly** (`Packet.h`, `RadioMeshCrc32.h`), NOT the `RadioMesh.h` umbrella; defines **no** `RM_LOG_*` (log macros stay no-ops); compiles **no** `src/*.cpp` (the round-trip slice is header-only).
+- **Two success gates:** (1) `pio run -e heltec_wifi_lora_32_V3` and `-e seeed_xiao_esp32s3` still build; (2) `pio test -e native` compiles the slice without Arduino and passes.
+- **Out of scope (do NOT touch):** Zephyr/`ports/zephyr/` content, file relocation, crypto/routing/framework/`DeviceBuilder`/`IRadio`, `Utils.cpp` internals.
+- **Packet facts (for tests):** `HEADER_LENGTH` == 35, `DEV_ID_LENGTH` == 4, `RM_PROTOCOL_VERSION` == 4, `PACKET_LENGTH` == 256.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `platformio.ini` | Build envs | **Modify** — add `[env:native]` |
+| `src/common/utils/RadioMeshCrc32.h` | CRC32 (header-only) | **Modify** — drop `<Arduino.h>` |
+| `src/common/inc/Options.h` | Platform macro + base types | **Modify** — `byte` typedef in host branch |
+| `src/common/inc/Logger.h` | Logging macros + `rmPrintf` | **Modify** — host output path + includes |
+| `src/common/utils/Utils.h` | Utility decls + templates | **Modify** — guard Arduino RNG in one template |
+| `test/test_Packet/test_Packet.cpp` | Host unit tests for the slice | **Create** |
+
+---
+
+## Task 1: Native test env + smoke test
+
+Stand up the `native` env end-to-end before fighting the de-Arduino compile, so a green here means "the host toolchain + Unity + `int main()` harness work" and later reds are unambiguously about RadioMesh code.
+
+**Files:**
+- Create: `test/test_Packet/test_Packet.cpp`
+- Modify: `platformio.ini` (append a new env)
+
+**Interfaces:**
+- Consumes: nothing (PlatformIO `native` platform, Unity).
+- Produces: a runnable `pio test -e native` target and a `test/test_Packet/` suite that later tasks extend. `int main(int, char**)` is the test entry point.
+
+- [ ] **Step 1: Write the smoke test**
+
+Create `test/test_Packet/test_Packet.cpp`:
+
+```cpp
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_env_smoke(void)
+{
+    TEST_ASSERT_EQUAL(1, 1);
+}
+
+int main(int, char**)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_env_smoke);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 2: Add the `native` env**
+
+Append to `platformio.ini` (after the last env):
+
+```ini
+[env:native]
+platform = native
+test_framework = unity
+test_filter = test_Packet
+lib_ldf_mode = off
+build_flags =
+    -std=gnu++17
+    -I ./include
+    -I ./src
+```
+
+Notes: `lib_ldf_mode = off` stops PlatformIO from auto-pulling the Arduino library graph from `lib_dir = ./src`; headers are found via the explicit `-I` paths. `test_filter = test_Packet` keeps the Arduino-only suites (`test_PacketTracker`, etc.) out of this env.
+
+- [ ] **Step 3: Run the smoke test**
+
+Run: `pio test -e native`
+Expected: PlatformIO installs the `native` platform on first run, then:
+```
+test/test_Packet/test_Packet.cpp:... test_env_smoke   [PASSED]
+...
+1 test cases: 1 succeeded
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platformio.ini test/test_Packet/test_Packet.cpp
+git commit -m "build: add PlatformIO native host-test env" -m "Assisted-by: Claude Code (Opus 4.8)"
+```
+
+---
+
+## Task 2: De-Arduino `RadioMeshCrc32.h` + host CRC test
+
+`RadioMeshCrc32.h` includes `<Arduino.h>` but uses only `uint8_t`/`uint32_t`/`size_t` — never `byte`. A CRC-only test needs only this one fix to go green, so it is the smallest independent slice.
+
+**Files:**
+- Modify: `src/common/utils/RadioMeshCrc32.h:3`
+- Modify: `test/test_Packet/test_Packet.cpp`
+
+**Interfaces:**
+- Consumes: `RadioMeshUtils::CRC32` — `void reset()`, `void update(const uint8_t* data, size_t length)`, `uint32_t finalize()`.
+- Produces: nothing new for later tasks (proves the CRC header is host-clean).
+
+- [ ] **Step 1: Add the CRC tests (they will fail to compile)**
+
+In `test/test_Packet/test_Packet.cpp`, add the include at the top (below `#include <unity.h>`):
+
+```cpp
+#include <common/utils/RadioMeshCrc32.h>
+```
+
+Add these two test functions:
+
+```cpp
+void test_crc32_is_deterministic(void)
+{
+    const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    RadioMeshUtils::CRC32 a;
+    a.update(data, sizeof(data));
+    RadioMeshUtils::CRC32 b;
+    b.update(data, sizeof(data));
+    TEST_ASSERT_EQUAL_HEX32(a.finalize(), b.finalize());
+}
+
+void test_crc32_detects_single_bit_change(void)
+{
+    const uint8_t data1[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    const uint8_t data2[] = {0xDE, 0xAD, 0xBE, 0xEE};
+    RadioMeshUtils::CRC32 a;
+    a.update(data1, sizeof(data1));
+    RadioMeshUtils::CRC32 b;
+    b.update(data2, sizeof(data2));
+    TEST_ASSERT_NOT_EQUAL(a.finalize(), b.finalize());
+}
+```
+
+(These are property tests — determinism and change-detection — deliberately NOT a hardcoded CRC constant, because this CRC32 reflects both input bytes and output and is not the standard zlib value.)
+
+Update `main()` to run them:
+
+```cpp
+int main(int, char**)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_env_smoke);
+    RUN_TEST(test_crc32_is_deterministic);
+    RUN_TEST(test_crc32_detects_single_bit_change);
+    return UNITY_END();
+}
+```
+
+- [ ] **Step 2: Run to verify it fails (compile error)**
+
+Run: `pio test -e native`
+Expected: FAIL — compile error, because `RadioMeshCrc32.h` includes `<Arduino.h>`:
+```
+src/common/utils/RadioMeshCrc32.h:3:10: fatal error: Arduino.h: No such file or directory
+```
+
+- [ ] **Step 3: Drop the Arduino include**
+
+In `src/common/utils/RadioMeshCrc32.h`, replace line 3:
+
+```cpp
+#include <Arduino.h>
+```
+
+with:
+
+```cpp
+#include <cstddef>
+#include <cstdint>
+```
+
+This is unconditional (no guard): `<cstddef>`/`<cstdint>` exist on the ESP32/Arduino toolchains too, and `CRC32` uses no Arduino symbol.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pio test -e native`
+Expected: PASS
+```
+test_env_smoke                     [PASSED]
+test_crc32_is_deterministic        [PASSED]
+test_crc32_detects_single_bit_change [PASSED]
+3 test cases: 3 succeeded
+```
+
+- [ ] **Step 5: Arduino regression gate**
+
+Run: `pio run -e heltec_wifi_lora_32_V3`
+Expected: `SUCCESS` (build unchanged). If it fails, some file relied on `RadioMeshCrc32.h` transitively including `<Arduino.h>`; add the missing include to *that* file rather than reverting.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/common/utils/RadioMeshCrc32.h test/test_Packet/test_Packet.cpp
+git commit -m "refactor: drop Arduino.h from RadioMeshCrc32 for host builds" -m "Assisted-by: Claude Code (Opus 4.8)"
+```
+
+---
+
+## Task 3: De-Arduino the Packet header chain + round-trip test
+
+`Packet.h` transitively pulls `Definitions.h` (needs `byte`), `Logger.h` (uses `OUTPUT_PORT`), and `Utils.h` (Arduino RNG in a template). These three block the host compile together, so they are one task ending in a green round-trip test.
+
+**Files:**
+- Modify: `src/common/inc/Options.h` (host branch, ~lines 7–10)
+- Modify: `src/common/inc/Logger.h` (includes near line 3; `rmPrintf` body line 62)
+- Modify: `src/common/utils/Utils.h` (`getRandomBytesArray`, ~lines 150–160)
+- Modify: `test/test_Packet/test_Packet.cpp`
+
+**Interfaces:**
+- Consumes: `RadioMeshPacket` — default ctor; fields `protocolVersion`, `sourceDevId`/`destDevId`/`packetId`/`lastHopId`/`nextHopId` (`std::array<byte,4>`), `topic`/`deviceType`/`hopCount` (`uint8_t`), `packetCrc`/`fcounter` (`uint32_t`), `packetData` (`std::vector<byte>`); `std::vector<byte> toByteBuffer() const`; `explicit RadioMeshPacket(const std::vector<byte>&)`. Macros `HEADER_LENGTH`, `DEV_ID_LENGTH`, `RM_PROTOCOL_VERSION`.
+- Produces: the packet slice now compiles host-side — the foundation M1 consumes.
+
+- [ ] **Step 1: Add the round-trip test (it will fail to compile)**
+
+In `test/test_Packet/test_Packet.cpp`, add the include (below the CRC include):
+
+```cpp
+#include <core/protocol/inc/packet/Packet.h>
+```
+
+Add the test:
+
+```cpp
+void test_packet_header_and_payload_roundtrip(void)
+{
+    RadioMeshPacket pkt;
+    pkt.protocolVersion = RM_PROTOCOL_VERSION;
+    pkt.sourceDevId = {0x01, 0x02, 0x03, 0x04};
+    pkt.destDevId = {0x05, 0x06, 0x07, 0x08};
+    pkt.packetId = {0xAA, 0xBB, 0xCC, 0xDD};
+    pkt.topic = 0x10;
+    pkt.deviceType = 0x02;
+    pkt.hopCount = 3;
+    pkt.packetCrc = 0x12345678;
+    pkt.fcounter = 42;
+    pkt.lastHopId = {0x11, 0x22, 0x33, 0x44};
+    pkt.nextHopId = {0x55, 0x66, 0x77, 0x88};
+    pkt.packetData = {0xDE, 0xAD, 0xBE, 0xEF};
+
+    std::vector<byte> buf = pkt.toByteBuffer();
+    TEST_ASSERT_EQUAL_UINT32(HEADER_LENGTH + 4, buf.size());
+
+    RadioMeshPacket parsed(buf);
+    TEST_ASSERT_EQUAL(pkt.protocolVersion, parsed.protocolVersion);
+    TEST_ASSERT_EQUAL(pkt.topic, parsed.topic);
+    TEST_ASSERT_EQUAL(pkt.deviceType, parsed.deviceType);
+    TEST_ASSERT_EQUAL(pkt.hopCount, parsed.hopCount);
+    TEST_ASSERT_EQUAL_HEX32(pkt.packetCrc, parsed.packetCrc);
+    TEST_ASSERT_EQUAL_UINT32(pkt.fcounter, parsed.fcounter);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.sourceDevId.data(), parsed.sourceDevId.data(), DEV_ID_LENGTH);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.destDevId.data(), parsed.destDevId.data(), DEV_ID_LENGTH);
+    TEST_ASSERT_EQUAL_UINT32(pkt.packetData.size(), parsed.packetData.size());
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.packetData.data(), parsed.packetData.data(), pkt.packetData.size());
+}
+```
+
+Update `main()` to add `RUN_TEST(test_packet_header_and_payload_roundtrip);` before `return UNITY_END();`.
+
+- [ ] **Step 2: Run — fails on `byte`**
+
+Run: `pio test -e native`
+Expected: FAIL — `Definitions.h` uses `byte` (line 29) with no host typedef:
+```
+src/common/inc/Definitions.h:29: error: 'byte' does not name a type
+```
+
+- [ ] **Step 3: Define `byte` in the host branch of `Options.h`**
+
+In `src/common/inc/Options.h`, change the `#else` (host) branch from:
+
+```cpp
+#else
+// generic build
+#include <stdio.h>
+#define RM_GENERIC_BUILD
+#endif
+```
+
+to:
+
+```cpp
+#else
+// generic build
+#include <cstdint>
+#include <cstdio>
+typedef uint8_t byte;
+#define RM_GENERIC_BUILD
+#endif
+```
+
+- [ ] **Step 4: Run — now fails on `OUTPUT_PORT`**
+
+Run: `pio test -e native`
+Expected: FAIL — `Logger.h`'s `rmPrintf` uses `OUTPUT_PORT`, defined only under `ARDUINO`:
+```
+src/common/inc/Logger.h:62: error: 'OUTPUT_PORT' was not declared in this scope
+```
+(may also report missing `va_list`/`std::nothrow`).
+
+- [ ] **Step 5: Add a host output path + includes to `Logger.h`**
+
+In `src/common/inc/Logger.h`, immediately after `#include "Options.h"` (line 3), add (keyed on
+the same `defined(ARDUINO)` condition that guards `OUTPUT_PORT`, so the two never diverge):
+
+```cpp
+#if !defined(ARDUINO)
+#include <cstdarg>
+#include <cstdio>
+#include <new>
+#endif
+```
+
+Then change the output line inside `rmPrintf` (line 62) from:
+
+```cpp
+    len = OUTPUT_PORT.write((const uint8_t*)buffer, len);
+```
+
+to:
+
+```cpp
+#if defined(ARDUINO)
+    len = OUTPUT_PORT.write((const uint8_t*)buffer, len);
+#else
+    len = fwrite(buffer, 1, len, stdout);
+#endif
+```
+
+This matches the existing `#if defined(ARDUINO)` guard that defines `OUTPUT_PORT`. The Zephyr-specific `printk` backend is a later (M1) refinement.
+
+- [ ] **Step 6: Run — now fails on `random`/`randomSeed`**
+
+Run: `pio test -e native`
+Expected: FAIL — `Utils.h`'s `getRandomBytesArray` template calls Arduino RNG (clang rejects these non-dependent names at definition):
+```
+src/common/utils/Utils.h:154: error: use of undeclared identifier 'randomSeed'
+src/common/utils/Utils.h:157: error: use of undeclared identifier 'random'
+```
+
+- [ ] **Step 7: Guard the Arduino RNG in `Utils.h`**
+
+In `src/common/utils/Utils.h`, add after the includes (after line 6, `#include <vector>`):
+
+```cpp
+#ifndef RM_ARDUINO_BUILD
+#include <cstdlib>
+#endif
+```
+
+Then replace the body of `getRandomBytesArray` (lines ~150–160) so the RNG calls are guarded:
+
+```cpp
+template <std::size_t length>
+std::array<byte, length> getRandomBytesArray()
+{
+    const char* digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    std::array<byte, length> bytes;
+#ifdef RM_ARDUINO_BUILD
+    randomSeed(simpleRNG(4));
+    for (std::size_t i = 0; i < length; i++) {
+        bytes[i] = digits[random(36)];
+    }
+#else
+    for (std::size_t i = 0; i < length; i++) {
+        bytes[i] = digits[std::rand() % 36];
+    }
+#endif
+    return bytes;
+}
+```
+
+(A `std::rand`-based host path avoids declaring a global `random`, which would clash with POSIX `long random(void)`.)
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `pio test -e native`
+Expected: PASS — all four tests:
+```
+test_env_smoke                            [PASSED]
+test_crc32_is_deterministic               [PASSED]
+test_crc32_detects_single_bit_change      [PASSED]
+test_packet_header_and_payload_roundtrip  [PASSED]
+4 test cases: 4 succeeded
+```
+
+- [ ] **Step 9: Arduino regression gate (both boards)**
+
+Run: `pio run -e heltec_wifi_lora_32_V3 && pio run -e seeed_xiao_esp32s3`
+Expected: `SUCCESS` for both — the shims are guarded, so Arduino output is unchanged.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/common/inc/Options.h src/common/inc/Logger.h src/common/utils/Utils.h test/test_Packet/test_Packet.cpp
+git commit -m "refactor: make core packet slice compile without Arduino" -m "Guarded byte typedef (Options.h), host stdout path in Logger rmPrintf, and a host RNG branch in Utils getRandomBytesArray. Verified via the native host test and unchanged heltec/xiao Arduino builds." -m "Assisted-by: Claude Code (Opus 4.8)"
+```
+
+---
+
+## Verification Summary (M0 done when all true)
+
+- [ ] `pio test -e native` passes (4 tests) — the slice compiles + round-trips with no Arduino.
+- [ ] `pio run -e heltec_wifi_lora_32_V3` builds.
+- [ ] `pio run -e seeed_xiao_esp32s3` builds.
+- [ ] Every shared-file edit is guarded (`RM_ARDUINO_BUILD`/`RM_GENERIC_BUILD` or `#if defined(ARDUINO)`), except the `RadioMeshCrc32.h` include which is safe on both toolchains.
+- [ ] No Zephyr content, no file moves, no changes outside the six files listed.
+
+## Notes / Deferred
+
+- On-target Unity suites (`test_heltec_wifi_lora_32_V3` etc.) run on hardware; M0's automated gate is the *compile* (`pio run`), plus host tests. Running on-device tests is optional this milestone.
+- `Utils.cpp` internals (e.g. `millis`, real RNG) remain Arduino-coupled; pulled in just-in-time by a later milestone.
+- Logger's Zephyr `printk`/`LOG_*` backend lands in M1.

--- a/docs/superpowers/specs/2026-07-18-zephyr-port-milestone0-design.md
+++ b/docs/superpowers/specs/2026-07-18-zephyr-port-milestone0-design.md
@@ -104,7 +104,9 @@ The minimal set of neutral source needed to build and round-trip a `RadioMeshPac
 - `src/common/inc/Definitions.h` — uses `byte` (e.g. line 397); topic/type enums
 - `src/common/inc/Options.h` — the `RM_ARDUINO_BUILD` / `RM_GENERIC_BUILD` gate (lines 1–11)
 - `src/common/inc/Logger.h` — has an existing `#if defined(ARDUINO) … #else std::cout` split
-- `src/common/utils/Utils.{h,cpp}` — hex helpers etc. (already free of the Arduino-isms grep set)
+- `src/common/utils/Utils.h` — pulled in transitively by `Packet.h`; must *parse* off-Arduino
+  (its `getRandomBytesArray` template references Arduino RNG — see §4.4). `Utils.cpp` is **not**
+  compiled in M0.
 
 The exact transitive include set is confirmed during implementation; the list above is the
 expected slice. Anything outside it (crypto, routing, framework, `IRadio`, HAL) is **out of
@@ -114,25 +116,44 @@ scope**.
 
 ## 4. Changes (all guarded by the existing platform macro)
 
+Every shared-file edit is guarded by `RM_ARDUINO_BUILD` / `RM_GENERIC_BUILD` (both defined in
+`Options.h`) so the Arduino preprocessor output is byte-identical. The de-Arduino surface below
+was corrected after a planning-time read of the slice's transitive headers, which found two
+Arduino dependencies the spec's original grep could not see (§4.3, §4.4).
+
 1. **`byte` typedef for non-Arduino** — in the existing `#else /* RM_GENERIC_BUILD */` branch
    of `Options.h`, add `#include <cstdint>` and `typedef uint8_t byte;` (Arduino supplies
-   `byte` via `<Arduino.h>`; the generic branch currently does not, which is the core gap).
-   Include ordering must ensure `byte` is defined before `Definitions.h` uses it.
+   `byte` via `<Arduino.h>`; the generic branch currently does not — the core gap). Include
+   ordering must ensure `byte` is defined before `Definitions.h` uses it.
 
-2. **`RadioMeshCrc32.h`** — replace `#include <Arduino.h>` with `#include <common/inc/Options.h>`,
-   which supplies `byte` and fixed-width ints under both platform branches. No behavioral change.
+2. **`RadioMeshCrc32.h`** — replace `#include <Arduino.h>` with `#include <cstdint>` and
+   `#include <cstddef>`. `CRC32` uses only `uint8_t`/`uint32_t`/`size_t`, never `byte`, so it
+   needs no platform header. No behavioral change.
 
-3. **New `[env:native]` in `platformio.ini`** — `platform = native`, **no** `framework`,
-   Unity test framework, C++17, building only the packet slice + its tests. Extends the
-   existing `common_test` conventions where possible.
+3. **`Logger.h` — non-Arduino output path (NOT deferrable).** `rmPrintf` is defined
+   unconditionally and calls `OUTPUT_PORT.write(...)`, but `OUTPUT_PORT` is `#define`d *only* in
+   the `ARDUINO` branch, so the file does not compile off-Arduino. Add a guarded `#else` output
+   path (`fwrite(buffer, 1, len, stdout)`) plus the includes `<Arduino.h>` was silently
+   supplying (`<cstdarg>`, `<cstdio>`, `<new>`). The Zephyr-specific backend (`printk`/`LOG_*`)
+   is a *later* refinement (M1); M0 adds only the generic stdout path.
 
-4. **`test/test_Packet/test_Packet.cpp`** — a new focused host test: build a
-   `RadioMeshPacket`, serialize via `toByteBuffer()`, parse via the buffer constructor,
-   assert field-for-field equality; assert CRC compute/verify. Must compile and run under
-   the `native` env with no Arduino.
+4. **`Utils.h` — RNG shim for non-Arduino.** `getRandomBytesArray()` is a template calling the
+   Arduino functions `random()`/`randomSeed()`; as *non-dependent* names these are rejected by
+   clang (the `native` compiler on macOS) at definition time, even uninstantiated. Add guarded
+   `RM_GENERIC_BUILD` shims (`std::rand`/`std::srand`-backed) so the header parses. `Utils.cpp`
+   internals are **not** touched (see §7).
 
-The `Logger.h` Zephyr `printk` branch is **deferred to M1** — the `native` build exercises
-the existing `std::cout` branch, so no logger change is needed in M0.
+5. **New `[env:native]` in `platformio.ini`** — `platform = native`, **no** `framework`,
+   `test_framework = unity`, C++17, include paths `-I ./include -I ./src`. It compiles no
+   `src/*.cpp` (the round-trip slice is header-only) and constrains the LDF so it does not pull
+   the Arduino library graph.
+
+6. **`test/test_Packet/test_Packet.cpp`** — a new focused host test using `int main()` (not
+   Arduino `setup()/loop()`), including the slice headers **directly** (`Packet.h`,
+   `RadioMeshCrc32.h`) — not the `RadioMesh.h` umbrella — and defining no `RM_LOG_*` (log
+   macros stay no-ops). Build a `RadioMeshPacket`, serialize via `toByteBuffer()`, parse via the
+   buffer constructor, assert field-for-field equality; compute a `CRC32` over a payload and
+   assert the value round-trips. Must compile and run under `native` with no Arduino.
 
 ---
 
@@ -165,8 +186,11 @@ Both gates green:
 
 - No Zephyr toolchain, board, devicetree, or `ports/zephyr/` content (that is M1).
 - No file relocation or directory restructure.
-- No changes to crypto, routing, framework, `DeviceBuilder`, or the `IRadio` interface.
-- No `Logger.h` `printk` branch (deferred to M1).
+- No changes to crypto, routing, framework, or `DeviceBuilder`.
+- No Zephyr-specific logging backend (`printk`/`LOG_*`) — M0 adds only the generic stdout
+  path; the Zephyr specialization is M1.
+- No de-Arduino of `Utils.cpp` internals — only `Utils.h` must *parse* off-Arduino. The `.cpp`
+  (and its `millis`/RNG usage) is pulled in just-in-time by a later milestone.
 - No fixing of the leaky `IRadio` abstraction (deferred to M6, done across both platforms).
 
 ---

--- a/docs/superpowers/specs/2026-07-18-zephyr-port-milestone0-design.md
+++ b/docs/superpowers/specs/2026-07-18-zephyr-port-milestone0-design.md
@@ -1,0 +1,181 @@
+# Zephyr Port — Milestone 0: De-Arduino-ify the Core Packet Slice
+
+**Date:** 2026-07-18
+**Status:** Design approved; ready for implementation planning
+**Repo:** RadioMesh (this repo — changes land here, in the current PlatformIO/Arduino project)
+
+---
+
+## 1. Project context & decisions (preamble)
+
+This milestone is the first deliverable of a larger effort: producing a **Zephyr RTOS
+port of RadioMesh** targeting the Seeed XIAO ESP32-S3 + Wio SX1262 kit. The port serves
+two goals — deepening Zephyr skills (used professionally at the author's employer) using a
+known-quantity protocol as the vehicle, and repositioning RadioMesh toward
+commercial/industrial users rather than hobbyists only.
+
+The following project-level decisions were made during brainstorming and constrain every
+milestone. They are recorded here so they are not lost; later milestones get their own
+specs but inherit these.
+
+### D1 — Monorepo, evolved in place, no rename, no user disruption
+The Zephyr port lives in the **current RadioMesh repo** (same name, same URL). It is **not**
+a new repo and **not** a multi-repo split. Existing PlatformIO users must remain
+undisturbed: `library.json`, `include/`, `src/`, `examples/`, `pio-config/` stay where they
+are and keep working. A multi-repo split (core + per-platform ports) is a *possible future*
+migration if independent port maintainers or divergent release cadences appear — not now.
+
+### D2 — Shared core by co-compilation (not a submodule or copy)
+The platform-neutral protocol code (`src/core`, `src/common`, neutral parts of
+`src/framework`) is shared between the Arduino and Zephyr builds by having **both build
+systems compile the same physical source files**. There is no submodule, no vendored copy,
+no separate core package. Consequence: wire-compatibility between Arduino and Zephyr nodes
+is guaranteed **by construction** — there is exactly one implementation of `Packet`, CRC,
+crypto, and routing on disk.
+
+### D3 — Dual-hat repo layout
+The repo carries two independent build manifests that never conflict:
+- **PlatformIO** reads `library.json` (root) and compiles `src/` recursively. It never sees
+  `zephyr/` or `ports/`.
+- **Zephyr** reads `zephyr/module.yml` (root) and a `west.yml` manifest; its CMake
+  co-compiles the neutral `src/` slice plus the Zephyr HAL in `ports/zephyr/`.
+
+```
+RadioMesh/
+├── library.json            # PIO reads this. UNCHANGED by the port.
+├── include/RadioMesh.h     # Arduino umbrella header. UNCHANGED.
+├── src/
+│   ├── common/             ┐ platform-neutral → compiled by BOTH builds
+│   ├── core/               ┘   (de-Arduino-ify happens here, guarded)
+│   ├── framework/          #   logic (neutral) + hardware wiring (Arduino)
+│   ├── hardware/           # Arduino HAL (RadioLib, EEPROM, U8g2, portal)
+│   └── main.cpp            # Arduino build only
+├── examples/               # Arduino — UNCHANGED
+├── platformio.ini          # Arduino — a `native` env is ADDED here in M0
+├── pio-config/             # Arduino build fragments — UNCHANGED (may gain a native fragment)
+├── zephyr/module.yml       # NEW (M1). west reads this. PIO ignores it.
+└── ports/zephyr/           # NEW (M1). Invisible to PIO.
+```
+Platform separation is **structural** (by directory) and, for shared files, **guarded by
+preprocessor macro** — never `#ifdef ARDUINO` scattered ad hoc through HAL logic.
+
+### D4 — Decomposition roadmap
+The full port is multi-subsystem and too large for one spec. It is decomposed into
+dependency-ordered milestones, each its own spec → plan → implementation:
+
+0. **De-Arduino-ify the core packet slice + add a host build gate** ← *this spec*
+1. Zephyr bring-up + two-node LoRa packet exchange (tracer bullet)
+2. Routing + relay (RoutingTable, PacketRouter, dedup)
+3. Secure messaging (AES-CTR, CMAC/MIC; rweather-vs-PSA crypto-backend decision)
+4. Persistent storage HAL (NVS / settings)
+5. Inclusion + KeyManager (Curve25519 ECDH; depends on 3 + 4)
+6. Device / DeviceBuilder framework parity (includes fixing the leaky `IRadio` abstraction)
+7. Display HAL (optional)
+8. WiFi + DevicePortal (highest uncertainty; may become a BLE/USB-config rethink)
+
+There is deliberately **no big upfront "extract the whole core" refactor**. Each milestone
+de-Arduino-ifies only the slice it needs, in place and guarded.
+
+### D5 — Interop preserved
+A Zephyr node and an Arduino node must be able to coexist on the same physical mesh (same
+packet framing, CRC, and — once M3 lands — byte-identical crypto/MIC). This is a direct
+consequence of D2.
+
+---
+
+## 2. Milestone 0 — Goal
+
+Make the **packet slice** of the protocol core compile with **zero Arduino dependency**,
+with every change **guarded** so the Arduino build's preprocessor output is byte-identical,
+and prove correctness from **both** sides (Arduino unchanged; non-Arduino compiles + passes
+tests).
+
+This milestone requires no Zephyr toolchain, no board, and no devicetree. It is a
+self-contained improvement to the current repo and the prerequisite that de-risks M1.
+
+---
+
+## 3. Scope — the "packet slice"
+
+The minimal set of neutral source needed to build and round-trip a `RadioMeshPacket`:
+
+- `src/core/protocol/inc/packet/Packet.h` — `RadioMeshPacket` (serialize/parse/CRC field)
+- `src/common/utils/RadioMeshCrc32.h` — CRC32 (currently `#include <Arduino.h>` at line 3)
+- `src/common/inc/Definitions.h` — uses `byte` (e.g. line 397); topic/type enums
+- `src/common/inc/Options.h` — the `RM_ARDUINO_BUILD` / `RM_GENERIC_BUILD` gate (lines 1–11)
+- `src/common/inc/Logger.h` — has an existing `#if defined(ARDUINO) … #else std::cout` split
+- `src/common/utils/Utils.{h,cpp}` — hex helpers etc. (already free of the Arduino-isms grep set)
+
+The exact transitive include set is confirmed during implementation; the list above is the
+expected slice. Anything outside it (crypto, routing, framework, `IRadio`, HAL) is **out of
+scope**.
+
+---
+
+## 4. Changes (all guarded by the existing platform macro)
+
+1. **`byte` typedef for non-Arduino** — in the existing `#else /* RM_GENERIC_BUILD */` branch
+   of `Options.h`, add `#include <cstdint>` and `typedef uint8_t byte;` (Arduino supplies
+   `byte` via `<Arduino.h>`; the generic branch currently does not, which is the core gap).
+   Include ordering must ensure `byte` is defined before `Definitions.h` uses it.
+
+2. **`RadioMeshCrc32.h`** — replace `#include <Arduino.h>` with `#include <common/inc/Options.h>`,
+   which supplies `byte` and fixed-width ints under both platform branches. No behavioral change.
+
+3. **New `[env:native]` in `platformio.ini`** — `platform = native`, **no** `framework`,
+   Unity test framework, C++17, building only the packet slice + its tests. Extends the
+   existing `common_test` conventions where possible.
+
+4. **`test/test_Packet/test_Packet.cpp`** — a new focused host test: build a
+   `RadioMeshPacket`, serialize via `toByteBuffer()`, parse via the buffer constructor,
+   assert field-for-field equality; assert CRC compute/verify. Must compile and run under
+   the `native` env with no Arduino.
+
+The `Logger.h` Zephyr `printk` branch is **deferred to M1** — the `native` build exercises
+the existing `std::cout` branch, so no logger change is needed in M0.
+
+---
+
+## 5. Why two verification gates
+
+"Still builds for Arduino" is **necessary but not sufficient**. The Arduino build keeps
+`<Arduino.h>` on the include path, so a lingering Arduino dependency would compile silently
+and stay hidden until Zephyr's compiler rejected it in M1. The only real proof that the
+Arduino-ectomy took is a **second compile path with no Arduino at all**. Hence a host
+`native` build is part of M0, not a later nicety.
+
+Bonus: a `native` env gives the existing Arduino project fast, hardware-free unit tests for
+protocol logic — value independent of the Zephyr port.
+
+---
+
+## 6. Success criteria
+
+Both gates green:
+
+1. **Arduino unchanged:** `pio run -e heltec_wifi_lora_32_V3` and
+   `pio run -e seeed_xiao_esp32s3` build successfully; existing on-target test envs are
+   unaffected (no source behavior change under `RM_ARDUINO_BUILD`).
+2. **Non-Arduino proven:** `pio test -e native` compiles the packet slice **without
+   Arduino** and passes the `test_Packet` round-trip + CRC assertions.
+
+---
+
+## 7. Non-goals
+
+- No Zephyr toolchain, board, devicetree, or `ports/zephyr/` content (that is M1).
+- No file relocation or directory restructure.
+- No changes to crypto, routing, framework, `DeviceBuilder`, or the `IRadio` interface.
+- No `Logger.h` `printk` branch (deferred to M1).
+- No fixing of the leaky `IRadio` abstraction (deferred to M6, done across both platforms).
+
+---
+
+## 8. Risks & notes
+
+- **Include ordering / `byte` visibility:** files that use `byte` must transitively include
+  `Options.h` (or the compat definition) before use. Verify `Definitions.h`'s include order.
+- **`native` platform quirks:** PlatformIO's `native` uses the host compiler; the slice must
+  avoid anything host-toolchain-specific. The slice is STL + fixed-width ints, so low risk.
+- **Scope creep:** the temptation is to de-Arduino-ify more than the packet slice while in
+  these files. Resist — later milestones pull in the rest, just-in-time.

--- a/platformio.ini
+++ b/platformio.ini
@@ -83,3 +83,13 @@ build_flags =
 	${common_test.build_flags}
 	-DRM_NO_DISPLAY
 	-fPIC
+
+[env:native]
+platform = native
+test_framework = unity
+test_filter = test_Packet
+lib_ldf_mode = chain
+build_flags =
+	-std=gnu++17
+	-I ./include
+	-I ./src

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,6 +89,15 @@ platform = native
 test_framework = unity
 test_filter = test_Packet
 lib_ldf_mode = chain
+; The native env compiles only the header-only slice (via -I ./src) plus Unity.
+; lib_dir = ./src makes each top-level src subdir an implicit library; ignore
+; them so LDF never compiles the Arduino-coupled src/*.cpp when a real header
+; (e.g. Packet.h) is included. Unity is still resolved.
+lib_ignore =
+	common
+	core
+	framework
+	hardware
 build_flags =
 	-std=gnu++17
 	-I ./include

--- a/src/common/inc/Logger.h
+++ b/src/common/inc/Logger.h
@@ -2,6 +2,12 @@
 
 #include "Options.h"
 
+#if !defined(ARDUINO)
+#include <cstdarg>
+#include <cstdio>
+#include <new>
+#endif
+
 #ifdef RM_LOG_VERBOSE
 #define LOG_ERROR
 #define LOG_WARN
@@ -59,7 +65,11 @@ rmPrintf(const char* format, ...)
         vsnprintf(buffer, len + 1, format, arg);
         va_end(arg);
     }
+#if defined(ARDUINO)
     len = OUTPUT_PORT.write((const uint8_t*)buffer, len);
+#else
+    len = fwrite(buffer, 1, len, stdout);
+#endif
     if (buffer != temp) {
         delete[] buffer;
     }

--- a/src/common/inc/Options.h
+++ b/src/common/inc/Options.h
@@ -6,7 +6,9 @@
 #define RM_ARDUINO_BUILD
 #else
 // generic build
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
+typedef uint8_t byte;
 #define RM_GENERIC_BUILD
 #endif
 

--- a/src/common/utils/RadioMeshCrc32.h
+++ b/src/common/utils/RadioMeshCrc32.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <Arduino.h>
+#include <cstddef>
+#include <cstdint>
 
 namespace RadioMeshUtils
 {

--- a/src/common/utils/Utils.h
+++ b/src/common/utils/Utils.h
@@ -5,6 +5,10 @@
 #include <string>
 #include <vector>
 
+#ifndef RM_ARDUINO_BUILD
+#include <cstdlib>
+#endif
+
 enum class DataFormat
 {
     DECIMAL,
@@ -151,11 +155,17 @@ template <std::size_t length>
 std::array<byte, length> getRandomBytesArray()
 {
     const char* digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    randomSeed(simpleRNG(4));
     std::array<byte, length> bytes;
+#ifdef RM_ARDUINO_BUILD
+    randomSeed(simpleRNG(4));
     for (std::size_t i = 0; i < length; i++) {
         bytes[i] = digits[random(36)];
     }
+#else
+    for (std::size_t i = 0; i < length; i++) {
+        bytes[i] = digits[std::rand() % 36];
+    }
+#endif
     return bytes;
 }
 } // namespace RadioMeshUtils

--- a/test/test_Packet/test_Packet.cpp
+++ b/test/test_Packet/test_Packet.cpp
@@ -1,5 +1,7 @@
 #include <unity.h>
 
+#include <common/utils/RadioMeshCrc32.h>
+
 void setUp(void) {}
 void tearDown(void) {}
 
@@ -8,9 +10,32 @@ void test_env_smoke(void)
     TEST_ASSERT_EQUAL(1, 1);
 }
 
+void test_crc32_is_deterministic(void)
+{
+    const uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    RadioMeshUtils::CRC32 a;
+    a.update(data, sizeof(data));
+    RadioMeshUtils::CRC32 b;
+    b.update(data, sizeof(data));
+    TEST_ASSERT_EQUAL_HEX32(a.finalize(), b.finalize());
+}
+
+void test_crc32_detects_single_bit_change(void)
+{
+    const uint8_t data1[] = {0xDE, 0xAD, 0xBE, 0xEF};
+    const uint8_t data2[] = {0xDE, 0xAD, 0xBE, 0xEE};
+    RadioMeshUtils::CRC32 a;
+    a.update(data1, sizeof(data1));
+    RadioMeshUtils::CRC32 b;
+    b.update(data2, sizeof(data2));
+    TEST_ASSERT_NOT_EQUAL(a.finalize(), b.finalize());
+}
+
 int main(int, char**)
 {
     UNITY_BEGIN();
     RUN_TEST(test_env_smoke);
+    RUN_TEST(test_crc32_is_deterministic);
+    RUN_TEST(test_crc32_detects_single_bit_change);
     return UNITY_END();
 }

--- a/test/test_Packet/test_Packet.cpp
+++ b/test/test_Packet/test_Packet.cpp
@@ -1,6 +1,7 @@
 #include <unity.h>
 
 #include <common/utils/RadioMeshCrc32.h>
+#include <core/protocol/inc/packet/Packet.h>
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -31,11 +32,45 @@ void test_crc32_detects_single_bit_change(void)
     TEST_ASSERT_NOT_EQUAL(a.finalize(), b.finalize());
 }
 
+void test_packet_header_and_payload_roundtrip(void)
+{
+    RadioMeshPacket pkt;
+    pkt.protocolVersion = RM_PROTOCOL_VERSION;
+    pkt.sourceDevId = {0x01, 0x02, 0x03, 0x04};
+    pkt.destDevId = {0x05, 0x06, 0x07, 0x08};
+    pkt.packetId = {0xAA, 0xBB, 0xCC, 0xDD};
+    pkt.topic = 0x10;
+    pkt.deviceType = 0x02;
+    pkt.hopCount = 3;
+    pkt.packetCrc = 0x12345678;
+    pkt.fcounter = 42;
+    pkt.lastHopId = {0x11, 0x22, 0x33, 0x44};
+    pkt.nextHopId = {0x55, 0x66, 0x77, 0x88};
+    pkt.packetData = {0xDE, 0xAD, 0xBE, 0xEF};
+
+    std::vector<byte> buf = pkt.toByteBuffer();
+    TEST_ASSERT_EQUAL_UINT32(HEADER_LENGTH + 4, buf.size());
+
+    RadioMeshPacket parsed(buf);
+    TEST_ASSERT_EQUAL(pkt.protocolVersion, parsed.protocolVersion);
+    TEST_ASSERT_EQUAL(pkt.topic, parsed.topic);
+    TEST_ASSERT_EQUAL(pkt.deviceType, parsed.deviceType);
+    TEST_ASSERT_EQUAL(pkt.hopCount, parsed.hopCount);
+    TEST_ASSERT_EQUAL_HEX32(pkt.packetCrc, parsed.packetCrc);
+    TEST_ASSERT_EQUAL_UINT32(pkt.fcounter, parsed.fcounter);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.sourceDevId.data(), parsed.sourceDevId.data(), DEV_ID_LENGTH);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.destDevId.data(), parsed.destDevId.data(), DEV_ID_LENGTH);
+    TEST_ASSERT_EQUAL_UINT32(pkt.packetData.size(), parsed.packetData.size());
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(pkt.packetData.data(), parsed.packetData.data(),
+                                  pkt.packetData.size());
+}
+
 int main(int, char**)
 {
     UNITY_BEGIN();
     RUN_TEST(test_env_smoke);
     RUN_TEST(test_crc32_is_deterministic);
     RUN_TEST(test_crc32_detects_single_bit_change);
+    RUN_TEST(test_packet_header_and_payload_roundtrip);
     return UNITY_END();
 }

--- a/test/test_Packet/test_Packet.cpp
+++ b/test/test_Packet/test_Packet.cpp
@@ -1,0 +1,16 @@
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_env_smoke(void)
+{
+    TEST_ASSERT_EQUAL(1, 1);
+}
+
+int main(int, char**)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_env_smoke);
+    return UNITY_END();
+}


### PR DESCRIPTION
### Description
Removes Arduino dependencies to allow native builds and facilitate porting to other OS/Platforms


### Related Issue(s)
N/A


### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Infrastructure/Build update
- [ ] Other 


### Testing
Ran pio tests on native host (Mac OS X Arm M4)


### Screenshots
N/A


### Additional Notes
N/A
